### PR TITLE
fix: use nodeFs for !Run existence check in launchApp (closes #15)

### DIFF
--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -137,9 +137,8 @@ function launchApp(nodeFs: NodeFsHost, hostPath: string): void {
     }
 
     const runScript = `$.${appName}.!Run`;              // e.g. "$.!Paint.!Run"
-    const runHost   = path.join(resolved, "!Run");
 
-    if (fs.existsSync(runHost)) {
+    if (nodeFs.stat(runScript) !== null) {
       // Normal RISC OS app: run the !Run Obey script
       dispatcher!.obey.runFile(runScript);
     } else {


### PR DESCRIPTION
## Summary

- Replaces `fs.existsSync(runHost)` (raw host path) with `nodeFs.stat(runScript) !== null` (RISC OS path) in `launchApp`
- Drops the now-unused `runHost` variable
- Makes `!Run` and `!RunImage` existence checks consistent — both go through `NodeFsHost`

Closes #15. Sibling to #13 / #14 which fixed the same issue for `!RunImage`.

## Test plan

- [ ] Launch an app that has `!Run` — it should still start normally
- [ ] Launch an app that has only `!RunImage` — should fall through to the binary loader as before
- [ ] Launch an app with neither — should show the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)