### PR TITLE
fix: guard loadProgram addr, simplify looksLikeObey, remove async_

### DIFF
--- a/packages/arm-emulator/src/machine.ts
+++ b/packages/arm-emulator/src/machine.ts
@@ -65,6 +65,7 @@ export class ArchimedesMachine {
    * (i.e. synchronously, since ticks are scheduled via setTimeout).
    */
   loadProgram(data: Uint8Array, addr = 0x8000): void {
+    if (addr < 8) throw new RangeError(`loadProgram: addr must be >= 8, got 0x${addr.toString(16)}`);
     this.bus.releaseROMAlias();
 
     // ARM branch encoding: 0xEA000000 | signed_offset_words

--- a/packages/risc-os/src/obey/obey.ts
+++ b/packages/risc-os/src/obey/obey.ts
@@ -177,21 +177,17 @@ function parentDir(riscosPath: string): string {
 
 /**
  * Heuristic: does the file content look like an Obey script rather than an ARM binary?
- * Obey files always begin with printable ASCII; ARM binaries begin with an instruction word.
+ * Obey scripts are plain ASCII text; ARM binaries will contain non-printable bytes.
  */
 function looksLikeObey(data: Uint8Array): boolean {
-  // Skip leading CR/LF/space
-  let i = 0;
-  while (i < data.length && (data[i] === 0x0D || data[i] === 0x0A || data[i] === 0x20)) i++;
-  if (i >= data.length) return false;
-
-  const first = data[i]!;
-  // '|' — Obey comment character
-  if (first === 0x7C) return true;
-
-  // Check for a leading keyword
-  const snippet = new TextDecoder().decode(data.subarray(i, Math.min(i + 16, data.length))).toUpperCase();
-  return /^(SET|SETMACRO|UNSET|RUN|RMLOAD|RMENSURE|WIMPSLOT|IF|ERROR|ECHO|ICONSPRITES)\b/.test(snippet);
+  if (data.length === 0) return false;
+  const limit = Math.min(data.length, 512);
+  for (let i = 0; i < limit; i++) {
+    const b = data[i]!;
+    // Allow printable ASCII, tab, LF, CR
+    if (b !== 0x09 && b !== 0x0A && b !== 0x0D && (b < 0x20 || b > 0x7E)) return false;
+  }
+  return true;
 }
 
 /** Evaluate a simple Obey If condition. */

--- a/packages/risc-os/src/swi/dispatcher.ts
+++ b/packages/risc-os/src/swi/dispatcher.ts
@@ -123,9 +123,7 @@ export class SwiDispatcher {
 
     cpu.swiHandlers.set(SWI.Wimp_Initialise, (r, b) => w.initialise(r, b));
 
-    // Async Wimp calls: wrap in a fire-and-forget that suspends the CPU
-    const async_ = (fn: () => Promise<void>) => () => { void fn(); };
-
+    // Async Wimp calls: fire-and-forget, suspending the CPU until wakeFromSWI()
     cpu.swiHandlers.set(SWI.Wimp_CreateWindow,
       (r, b) => { m.cpu.swiPending = true; void w.createWindow(r, b).then(() => m.wakeFromSWI()); });
 
@@ -196,8 +194,6 @@ export class SwiDispatcher {
       cpu.swiHandlers.set(n, stub);
     }
 
-    // Suppress void from async_ usage warning
-    void async_;
   }
 
   /** Inject a Wimp event from the host (e.g. user clicked a button) */


### PR DESCRIPTION
## Summary

- **#11** `arm-emulator`: `loadProgram` now throws a `RangeError` immediately when `addr < 8`, preventing the unsigned right-shift from silently encoding a large backward branch.
- **#10** `risc-os`: Replaced the `looksLikeObey` keyword/prefix heuristic with a binary-byte scan — if any byte in the first 512 bytes is non-printable (outside tab/LF/CR/printable ASCII), the file is treated as an ARM binary. This naturally handles bare RISC OS paths (`$.!Paint.!RunImage`) and any future Obey syntax without needing a keyword list.
- **#12** `risc-os`: Removed the unused `async_` wrapper and its `void async_` suppression from `SwiDispatcher`.

## Test plan

- [ ] Build passes (`pnpm --filter arm-emulator run build`, `pnpm --filter risc-os run build`)
- [ ] `loadProgram(data, 4)` throws `RangeError`; `loadProgram(data, 0x8000)` works as before
- [ ] A `!Run` file starting with `$.!Paint.!RunImage` is correctly identified as Obey and executed as a script, not passed to `runBinary`
- [ ] A real ARM binary (first bytes `0xEA...`) is correctly identified as binary

Closes #10, #11, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)