### PR TITLE
feat(memc): CAM-based logical-to-physical address translation

### DIFF
--- a/packages/arm-emulator/src/chips/memc.ts
+++ b/packages/arm-emulator/src/chips/memc.ts
@@ -2,10 +2,10 @@
  * MEMC (Memory Controller) - Acorn Archimedes
  *
  * The MEMC handles:
- *  - Logical-to-physical address translation (page tables)
+ *  - Logical-to-physical address translation (page tables via CAM)
  *  - DMA for VIDC (video and sound)
  *  - OS/application memory protection
- *  - ROM alias control (bit 0 of CAM / control register)
+ *  - ROM alias control
  *
  * Control register bits (written to address 0x36E0_0000+):
  *   bits 11:8  – DMA sound buffer (half-page select)
@@ -13,9 +13,31 @@
  *   bit 1      – Sound DMA enable
  *   bit 0      – Video DMA enable
  *
- * CAM (Content Addressable Memory) entries are written by ARM page-table
- * accesses.  We simplify to a flat mapping here.
+ * CAM entries are programmed by ARM writes to the address range
+ * 0x3600_0000–0x37FF_FFFF (bus-space equivalent of hardware 0x0360_0000–0x037F_FFFF).
+ * Only the write address encodes the mapping; the data value is ignored.
+ *
+ * CAM write address layout (offset from CAM_BASE, by page size index S):
+ *   bits [20:14]             – Logical Page Number (LPN), 7−S bits wide
+ *   bits [13:12]             – Protection level (PPL), 2 bits
+ *   bits [(pageShift−10):2]  – Physical Page Number (PPN), 10−S bits wide
+ *
+ * Page sizes and CAM capacity:
+ *   S=0 → 4 KB, 128 entries   S=2 → 16 KB, 32 entries
+ *   S=1 → 8 KB,  64 entries   S=3 → 32 KB, 16 entries
  */
+
+/** Physical RAM base address (matches SystemBus PHYS_RAM_BASE) */
+const PHYS_RAM_BASE = 0x0200_0000;
+
+/** Maximum CAM entries (4 KB page mode) */
+const MAX_CAM_ENTRIES = 128;
+
+interface CamEntry {
+  valid: boolean;
+  ppn:   number;  // physical page number
+  ppl:   number;  // protection level 0–3
+}
 
 export class MEMC {
   control = 0;
@@ -28,9 +50,32 @@ export class MEMC {
   /** Sound DMA start address (physical) */
   soundDMAStart = 0x0200_0000;
 
+  /** CAM: indexed by logical page number */
+  private cam: CamEntry[] = [];
+
+  constructor() {
+    this.initCam();
+    this.resetIdentityMap();
+  }
+
+  private initCam(): void {
+    this.cam = Array.from({ length: MAX_CAM_ENTRIES }, () => ({
+      valid: false, ppn: 0, ppl: 0,
+    }));
+  }
+
   /** Page size index: 0=4KB, 1=8KB, 2=16KB, 3=32KB */
+  get pageSizeIndex(): number {
+    return (this.control >>> 2) & 0x3;
+  }
+
   get pageSize(): number {
-    return 4096 << ((this.control >>> 2) & 0x3);
+    return 4096 << this.pageSizeIndex;
+  }
+
+  /** Number of active CAM entries for the current page size */
+  get maxCamEntries(): number {
+    return MAX_CAM_ENTRIES >>> this.pageSizeIndex;
   }
 
   get videoDMAEnabled(): boolean {
@@ -63,10 +108,67 @@ export class MEMC {
     }
   }
 
+  /**
+   * Decode a CAM entry from a write-address offset (relative to CAM_BASE).
+   * The data value is ignored per hardware spec — only the address matters.
+   *
+   * Address layout (4 KB pages, S=0):
+   *   offset[20:14] = LPN[6:0]
+   *   offset[13:12] = PPL[1:0]
+   *   offset[11:2]  = PPN[9:0]
+   */
+  writeCam(offset: number): void {
+    const s         = this.pageSizeIndex;
+    const pageShift = 12 + s;
+    const lpnBits   = 7 - s;   // 7, 6, 5, or 4
+    const ppnBits   = 10 - s;  // 10, 9, 8, or 7
+    const ppnShift  = pageShift - 10;  // 2, 3, 4, or 5
+
+    const lpn = (offset >>> 14) & ((1 << lpnBits) - 1);
+    const ppl = (offset >>> 12) & 0x3;
+    const ppn = (offset >>> ppnShift) & ((1 << ppnBits) - 1);
+
+    if (lpn < this.cam.length) {
+      this.cam[lpn] = { valid: true, ppn, ppl };
+    }
+  }
+
+  /**
+   * Translate a logical address to a physical bus address using the CAM.
+   * Returns null if no valid mapping exists (triggers an address abort).
+   */
+  translateAddress(logical: number): number | null {
+    const s         = this.pageSizeIndex;
+    const pageShift = 12 + s;
+    const pageMask  = (1 << pageShift) - 1;
+    const lpn       = logical >>> pageShift;
+
+    if (lpn >= this.maxCamEntries) return null;
+
+    const entry = this.cam[lpn];
+    if (!entry?.valid) return null;
+
+    return PHYS_RAM_BASE + (entry.ppn << pageShift) + (logical & pageMask);
+  }
+
   reset(): void {
     this.control       = 0;
     this.videoDMAStart = 0x0200_0000;
     this.videoDMAEnd   = 0x0200_0000;
     this.soundDMAStart = 0x0200_0000;
+    this.initCam();
+    this.resetIdentityMap();
+  }
+
+  /**
+   * Populate the CAM with an identity mapping (logical page N → physical page N)
+   * for all available slots.  This preserves flat-memory behaviour before a real
+   * ROM reprograms the page tables.
+   */
+  private resetIdentityMap(): void {
+    const count = this.maxCamEntries;
+    for (let lpn = 0; lpn < count; lpn++) {
+      this.cam[lpn] = { valid: true, ppn: lpn, ppl: 0 };
+    }
   }
 }

--- a/packages/arm-emulator/src/cpu/arm2.ts
+++ b/packages/arm-emulator/src/cpu/arm2.ts
@@ -448,6 +448,10 @@ export class ARM2CPU {
       this.takeException(VECTOR_FIQ, Mode.FIQ);
     }
   }
+
+  triggerDataAbort(): void {
+    this.takeException(VECTOR_DABORT, Mode.Supervisor);
+  }
 }
 
 function popcount(n: number): number {

--- a/packages/arm-emulator/src/machine.ts
+++ b/packages/arm-emulator/src/machine.ts
@@ -48,6 +48,7 @@ export class ArchimedesMachine {
 
     this.ioc.onIRQ = () => this.cpu.triggerIRQ();
     this.ioc.onFIQ = () => this.cpu.triggerFIQ();
+    this.bus.onDataAbort = () => this.cpu.triggerDataAbort();
   }
 
   loadROM(data: Uint8Array): void {

--- a/packages/arm-emulator/src/memory/bus.ts
+++ b/packages/arm-emulator/src/memory/bus.ts
@@ -3,14 +3,15 @@
  *
  * Physical memory map (ARM2 physical addresses):
  *
- *   0x0000_0000 – 0x01FF_FFFF  Logical RAM (via MEMC)
+ *   0x0000_0000 – 0x01FF_FFFF  Logical RAM (MEMC CAM-translated)
  *   0x0200_0000 – 0x03FF_FFFF  Physical RAM (up to 4MB on A305/A310)
  *   0x0400_0000 – 0x1FFF_FFFF  (unmapped / expansion)
  *   0x2000_0000 – 0x27FF_FFFF  I/O (IOC) and Video (VIDC) registers
  *   0x3200_0000 – 0x3200_001F  IOC registers
  *   0x3500_0000 – 0x35FF_FFFF  VIDC write-only registers
- *   0x36E0_0000 – 0x36FF_FFFF  MEMC control registers
- *   0x3400_0000 – 0x37FF_FFFF  ROM (4 MB window)
+ *   0x3600_0000 – 0x37FF_FFFF  MEMC CAM write range
+ *     0x36E0_0000 – 0x36FF_FFFF  MEMC control registers (sub-range of CAM)
+ *   0x3400_0000 – 0x37FF_FFFF  ROM (4 MB window, read-only)
  *
  * At reset, ROM is also visible at 0x0000_0000 until MEMC releases.
  */
@@ -19,20 +20,26 @@ import type { VIDC } from "../chips/vidc.js";
 import type { MEMC } from "../chips/memc.js";
 import type { IOC }  from "../chips/ioc.js";
 
-const ROM_BASE   = 0x3400_0000;
-const ROM_END    = 0x37FF_FFFF;
-const VIDC_BASE  = 0x3500_0000;
-const VIDC_END   = 0x35FF_FFFF;
-const IOC_BASE   = 0x3200_0000;
-const IOC_END    = 0x323F_FFFF;
-const MEMC_BASE  = 0x36E0_0000;
-const MEMC_END   = 0x36FF_FFFF;
+const ROM_BASE      = 0x3400_0000;
+const ROM_END       = 0x37FF_FFFF;
+const VIDC_BASE     = 0x3500_0000;
+const VIDC_END      = 0x35FF_FFFF;
+const IOC_BASE      = 0x3200_0000;
+const IOC_END       = 0x323F_FFFF;
+const CAM_BASE      = 0x3600_0000;
+const CAM_END       = 0x37FF_FFFF;
+const MEMC_BASE     = 0x36E0_0000;
+const MEMC_END      = 0x36FF_FFFF;
 const PHYS_RAM_BASE = 0x0200_0000;
+const LOGICAL_END   = 0x01FF_FFFF;
 
 export class SystemBus {
   private ram: Uint8Array;
   private rom: Uint8Array;
   private romActive = true; // ROM mapped at 0 until MEMC releases
+
+  /** Called when a logical-address translation fault occurs (no CAM match). */
+  onDataAbort?: () => void;
 
   constructor(
     ramBytes: number,
@@ -76,9 +83,8 @@ export class SystemBus {
     if (aligned >= PHYS_RAM_BASE && aligned < PHYS_RAM_BASE + this.ram.length) {
       return this.readRAM32(aligned - PHYS_RAM_BASE);
     }
-    if (aligned < this.ram.length) {
-      // Logical RAM (simplified — MEMC translation omitted)
-      return this.readRAM32(aligned);
+    if (aligned <= LOGICAL_END) {
+      return this.readLogical(aligned);
     }
     return 0xDEAD_BEEF; // open bus
   }
@@ -91,8 +97,13 @@ export class SystemBus {
       this.vidc.write(value >>> 0);
       return;
     }
-    if (aligned >= MEMC_BASE && aligned <= MEMC_END) {
-      this.memc.writeControl(aligned - MEMC_BASE, value >>> 0);
+    // CAM range (0x3600_0000–0x37FF_FFFF) includes the MEMC control subrange.
+    if (aligned >= CAM_BASE && aligned <= CAM_END) {
+      if (aligned >= MEMC_BASE && aligned <= MEMC_END) {
+        this.memc.writeControl(aligned - MEMC_BASE, value >>> 0);
+      } else {
+        this.memc.writeCam(aligned - CAM_BASE);
+      }
       return;
     }
     if (aligned >= IOC_BASE && aligned <= IOC_END) {
@@ -103,8 +114,8 @@ export class SystemBus {
       this.writeRAM32(aligned - PHYS_RAM_BASE, value >>> 0);
       return;
     }
-    if (aligned < this.ram.length) {
-      this.writeRAM32(aligned, value >>> 0);
+    if (aligned <= LOGICAL_END) {
+      this.writeLogical(aligned, value >>> 0);
     }
     // ROM writes are ignored
   }
@@ -125,6 +136,27 @@ export class SystemBus {
     const shift = (addr & 3) * 8;
     const old = this.read32(aligned);
     this.write32(aligned, (old & ~(0xFF << shift)) | ((value & 0xFF) << shift));
+  }
+
+  // --------------------------------------------------------------------------
+  // Logical RAM (MEMC CAM-translated)
+  // --------------------------------------------------------------------------
+  private readLogical(logical: number): number {
+    const phys = this.memc.translateAddress(logical);
+    if (phys === null) {
+      this.onDataAbort?.();
+      return 0;
+    }
+    return this.readRAM32(phys - PHYS_RAM_BASE);
+  }
+
+  private writeLogical(logical: number, value: number): void {
+    const phys = this.memc.translateAddress(logical);
+    if (phys === null) {
+      this.onDataAbort?.();
+      return;
+    }
+    this.writeRAM32(phys - PHYS_RAM_BASE, value);
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Implements the MEMC1a CAM (Content Addressable Memory) for logical→physical address translation, closing #9
- `writeCam(offset)` decodes LPN/PPL/PPN from the write address per MEMC1a spec; bit widths scale with page size index S (4KB/8KB/16KB/32KB all handled)
- `translateAddress(logical)` walks the CAM and returns the physical bus address, or `null` on a translation fault
- `reset()` installs an identity map (LPN N → PPN N) so flat-memory behaviour is preserved before a real ROM reprograms the page tables
- `bus.ts`: routes writes to `0x3600_0000–0x37FF_FFFF` as CAM writes; logical reads/writes now go through `translateAddress()` and fire `onDataAbort` on fault
- `arm2.ts`: adds `triggerDataAbort()` (vectors to `VECTOR_DABORT` in Supervisor mode)
- `machine.ts`: wires `bus.onDataAbort → cpu.triggerDataAbort()`

## Test plan

- [ ] `pnpm --filter @theprogramminggiantpanda/arm-emulator run build` passes with no errors
- [ ] Full build (`risc-os`, `electron-shell`) passes clean
- [ ] Existing SWI-based programs still run (identity map means no behaviour change at reset)
- [ ] Writing a CAM entry to `0x3600_0000 + (lpn << 14) | (ppn << 2)` and then reading the mapped logical address returns data from the correct physical page
- [ ] Access to an unmapped logical page triggers a data abort (vectors to `0x10`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)