### PR TITLE
feat: ROM boot mode + HostFS directory pass-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
 # Acorn Desktop
 
-An Acorn Archimedes emulator that runs RISC OS programs on Windows, Linux, and macOS.
+An Acorn Archimedes emulator that boots real RISC OS ROM images on Windows, Linux, and macOS.
 
-Instead of emulating the hardware display (VIDC frame buffer), it intercepts RISC OS Wimp SWI calls and maps each RISC OS window to a real native OS window via Electron. The result is a RISC OS application environment that looks and feels like a native desktop app.
+The real RISC OS ROM executes from address 0 just as it would on hardware. Wimp SWI calls are intercepted and each RISC OS window is mapped to a real native OS window via Electron, so the desktop looks and feels native. Host directories are accessible to RISC OS programs via the built-in HostFS filing system.
 
 ## How it works
 
-The ARM2/ARM3 CPU executes RISC OS machine code. When the program calls a Wimp SWI (e.g. `Wimp_CreateWindow`), the emulator intercepts it and creates a real `BrowserWindow` instead of writing pixels to a frame buffer. File I/O SWIs are forwarded to the host file system. Mouse clicks, key presses, and window events flow back into the emulated CPU via the `Wimp_Poll` event queue.
-
 ```
-ARM program code
-      │
+RISC OS ROM
+      │ boots, initialises modules, starts Filer
       ▼
   ARM2 CPU (arm2.ts)
       │ SWI instruction
@@ -26,15 +24,17 @@ ARM program code
       │                                                         ▼
       │                                               Electron BrowserWindow (per RISC OS window)
       │
-      └─ OS_File / OS_Find / OS_BGet / OS_GBPB … ──────────────────┐
+      ├─ OS_File / OS_Find / OS_GBPB / OS_Args  ────────────────────┐
+      │   (path starts with "HostFS::")                             ▼
+      │                                                  HostFsHandler (hostfs-handler.ts)
+      │                                                       │ Node.js fs
+      │                                                       ▼
+      │                                               Host file system (configurable root)
+      │
+      └─ all other SWIs ────────────────────────────────────────────┐
                                                                     ▼
-                                                          OSFileHandler (os-fs.ts)
-                                                              │ FileSystemHost interface
-                                                              ▼
-                                                         NodeFsHost (node-fs-host.ts)
-                                                              │
-                                                              ▼
-                                                       Host file system (~/Documents/RISCOS)
+                                                          ROM FileSwitch / OS kernel
+                                                          (ADFS, RAM disc, modules…)
 ```
 
 ## Packages
@@ -50,6 +50,7 @@ ARM program code
 
 - Node.js 18+
 - pnpm 8+
+- A RISC OS ROM image (see [ROM images](#rom-images))
 
 ```sh
 npm install -g pnpm
@@ -63,7 +64,7 @@ pnpm build
 pnpm start
 ```
 
-Then click **Load ROM** and select a RISC OS ROM image (`.rom`, `.bin`, or `.img`). You can also drag a ROM file onto the launcher window.
+Place a RISC OS ROM image (`.rom`, `.bin`, or `.img`) in `assets/roms/`. The emulator loads it automatically on startup. You can also click **Load ROM** in the menu or drag a ROM file onto the launcher window.
 
 ## Development
 
@@ -71,7 +72,7 @@ Then click **Load ROM** and select a RISC OS ROM image (`.rom`, `.bin`, or `.img
 pnpm dev
 ```
 
-This starts the Electron app in dev mode with hot-reload for the renderer and watch mode for the main process TypeScript.
+Starts the Electron app in dev mode with hot-reload for the renderer and watch mode for the main process TypeScript.
 
 ### Build order
 
@@ -107,7 +108,7 @@ The CPU is a full ARMv2 implementation:
 - Single and block data transfer (LDR/STR, LDM/STM — all four IA/IB/DA/DB addressing modes)
 - Branch and branch-with-link
 - Multiply and multiply-accumulate
-- SWI dispatch with registered handlers
+- SWI dispatch: registered handlers are checked first; returning `'passthrough'` falls through to the ROM SWI vector
 - Exception vectors (Reset, Undefined, SWI, Prefetch Abort, Data Abort, IRQ, FIQ)
 - ARM2 R15 encodes both PC and PSR (flags, mode, IRQ/FIQ mask bits)
 
@@ -116,7 +117,7 @@ ARM3 support adds a coprocessor CP15 cache-flush stub but is otherwise instructi
 ### Memory map
 
 ```
-0x0000_0000 – 0x01FF_FFFF   Logical RAM (via MEMC)
+0x0000_0000 – 0x01FF_FFFF   Logical RAM (via MEMC CAM)
 0x0200_0000 – 0x03FF_FFFF   Physical RAM (up to 4 MB)
 0x3200_0000 – 0x323F_FFFF   IOC (I/O controller)
 0x3400_0000 – 0x37FF_FFFF   ROM (4 MB window)
@@ -124,7 +125,20 @@ ARM3 support adds a coprocessor CP15 cache-flush stub but is otherwise instructi
 0x36E0_0000 – 0x36FF_FFFF   MEMC control registers
 ```
 
-ROM is also aliased at address 0 until MEMC releases it (standard Archimedes reset behaviour).
+ROM is aliased at address 0 on reset. The ROM releases the alias itself by writing the MEMC control register during its boot sequence.
+
+### Boot sequence
+
+The real RISC OS ROM boots from address 0:
+
+1. ROM initialises MEMC, IOC, and writes its own exception vectors into RAM
+2. ROM releases the ROM alias by writing the MEMC control register
+3. ROM initialises the module system (FileSwitch, ADFS, RAM disc, Filer, etc.)
+4. The Wimp starts and the desktop appears
+
+A 50 Hz vertical-blank IRQ is generated unconditionally (without VIDC rendering) so the ROM's cooperative task switcher fires correctly.
+
+Before the ROM boots, `assets/programs/` is scanned for RISC OS `!App` directories. Each app's `!Boot` Obey script is executed (or its `!Sprites` loaded directly) to register file type associations and load app sprites into the system sprite pool.
 
 ### Native window mode
 
@@ -136,22 +150,50 @@ No VIDC pixel rendering takes place. Instead:
 - Mouse clicks and key presses in a `BrowserWindow` are sent via IPC to the main process and delivered to the emulated CPU as Wimp events
 - The iconbar is a persistent, frameless, always-on-bottom `BrowserWindow`
 
-### Boot sequence
+### HostFS
 
-On startup, the emulator scans `assets/programs/` for RISC OS application directories (names beginning with `!`) and boots them in alphabetical order, mirroring the behaviour of the RISC OS Filer when it first opens a directory:
+HostFS exposes a host directory to RISC OS programs using the path prefix `HostFS::`.
 
-1. If the app has a `!Boot` Obey script, it is executed. This sets system variables (e.g. `AppName$Dir`, `AppName$Path`), registers file type associations, and loads the app's sprites.
-2. If the app has no `!Boot` but has a `!Sprites` file, the sprites are loaded directly.
+**Path format:**
 
-Variables set during boot (e.g. `File$Type_FCA`) remain live for the duration of the session and are visible to any subsequently launched application.
+| RISC OS path | Host path |
+|---|---|
+| `HostFS::$` | `{root}` |
+| `HostFS::$.Programs.!Paint` | `{root}/Programs/!Paint` |
+
+The root directory defaults to the directory from which the app or ROM was launched (typically `assets/programs/`).
+
+**File type preservation — `,xyz` suffix convention:**
+
+RISC OS files carry a 12-bit file type encoded in the load address. On a native filesystem these are preserved using the standard `,xyz` filename suffix (three lowercase hex digits):
+
+| Host filename | RISC OS name | File type |
+|---|---|---|
+| `Document,fff` | `Document` | 0xFFF (untyped) |
+| `Letter,ffc` | `Letter` | 0xFFC (Text) |
+| `Sprite,ff9` | `Sprite` | 0xFF9 (Sprite) |
+
+When reading, the `,xyz` suffix is stripped and the file type is encoded into the RISC OS load/exec address words (including a RISC OS 5-byte centisecond timestamp derived from the host file's mtime). When writing, the correct `,xyz` suffix is appended and any stale copy with a different suffix is removed.
+
+Files without a `,xyz` suffix are presented as untyped (`load=0xFFFFFFFF`).
+
+**SWI coverage:**
+
+| SWI | Reason codes | Notes |
+|---|---|---|
+| `OS_File` | 0 (save block), 5 (stat), 8 (mkdir), 255 (load) | Save appends `,xyz` from load addr |
+| `OS_Find` | 0x40 read, 0x80 write, 0xC0 update, 0x00 close | Writes buffered in memory, flushed on close |
+| `OS_Args` | 0 get ptr, 1 set ptr, 2 get extent, 255 flush | |
+| `OS_GBPB` | 1–2 write, 3–4 read, 9/10/11/12 dir listing | Dir listing returns bare names + full catalogue info |
+| `OS_FSControl` | 0 select, 36 canonicalise | |
+
+All other paths (not beginning with `HostFS::`) return `'passthrough'` and are handled by the real ROM FileSwitch (ADFS, RAM disc, etc.).
 
 ### Sprites
 
 RISC OS sprite files (`.!Sprites`) are parsed and decoded at boot time by `SpritePool` in `packages/risc-os/src/sprite/sprite-pool.ts`.
 
 **File format:**
-
-Sprite files omit the first "area size" word that is present in memory-resident sprite areas. All stored offsets are therefore 4 bytes larger than their file-relative positions.
 
 | Region | Layout |
 |---|---|
@@ -165,49 +207,17 @@ Colour words use the format: bits 8–15 = red, 16–23 = green, 24–31 = blue.
 
 Default palettes are provided for 1, 2, 4, and 8 bpp modes. An embedded palette in the sprite overrides the default.
 
-**Path-variable resolution:**
-
-The Obey `IconSprites` command supports the RISC OS path-variable syntax (`AppName:filename`). `AppName:` is expanded to the value of the `AppName$Path` system variable before the file is read.
-
-### File system
-
-File I/O SWIs are forwarded to the host OS via a `FileSystemHost` interface. The default implementation (`NodeFsHost`) uses synchronous Node.js `fs` APIs, mirroring the blocking behaviour of real Archimedes hardware.
-
-The RISC OS filing system root (`$`) maps to `~/Documents/RISCOS` on the host. The directory is created automatically on first launch.
-
-**Path translation:**
-
-| RISC OS | Host equivalent |
-|---|---|
-| `$` | `~/Documents/RISCOS` |
-| `$.Apps.Paint` | `~/Documents/RISCOS/Apps/Paint` |
-| `@` | current selected directory |
-| `^` | parent directory (`..`) |
-| `:Volume.$` | volume prefix stripped, treated as `$` |
-
-**File system SWI coverage:**
-
-| SWI | Reason codes implemented |
-|---|---|
-| `OS_File` | 0 (save block), 5 (stat), 6 (delete), 7 (create), 255 (load) |
-| `OS_Find` | 0x40 read, 0x80 write, 0xC0 read/write, 0x00 close |
-| `OS_Args` | 0 get ptr, 1 set ptr, 2 get extent, 3 set extent, 255 flush |
-| `OS_BGet` | read byte, C=1 on EOF |
-| `OS_BPut` | write byte |
-| `OS_GBPB` | 1–4 block read/write, 8 directory listing |
-| `OS_FSControl` | 26 set CSD, 36 canonicalise path |
-
 ### Supported SWIs
 
 **OS core:** `OS_WriteC`, `OS_Write0`, `OS_WriteN`, `OS_NewLine`, `OS_Exit`, `OS_GetEnv`, `OS_Byte`, `OS_Mouse`, `OS_ReadModeVar`, `OS_Heap`, `OS_Module`, `OS_IntOn`, `OS_IntOff`
 
-**File system:** `OS_File`, `OS_Find`, `OS_Args`, `OS_BGet`, `OS_BPut`, `OS_GBPB`, `OS_FSControl`
+**HostFS:** `OS_File`, `OS_Find`, `OS_Args`, `OS_GBPB`, `OS_FSControl` (for `HostFS::` paths only; all other paths pass through to ROM)
 
 **Wimp:** `Wimp_Initialise`, `Wimp_CreateWindow`, `Wimp_OpenWindow`, `Wimp_CloseWindow`, `Wimp_DeleteWindow`, `Wimp_Poll`, `Wimp_PollIdle`, `Wimp_RedrawWindow`, `Wimp_UpdateWindow`, `Wimp_GetWindowState`, `Wimp_ForceRedraw`, `Wimp_CreateIcon`, `Wimp_CreateMenu`, `Wimp_ReportError`, `Wimp_GetPointerInfo`, `Wimp_SlotSize`, `Wimp_ReadSysInfo`, `Wimp_SendMessage`, `Wimp_CloseDown`
 
 **Font:** `Font_FindFont`, `Font_LoseFont`, `Font_Paint`, `Font_StringWidth`, `Font_SetFontColours` (stubs)
 
-Unhandled SWIs vector to the ROM exception handler in the normal ARMv2 way.
+All other SWIs are handled by the ROM.
 
 ## Project structure
 
@@ -220,23 +230,23 @@ acorn-desktop/
 │   ├── arm-emulator/
 │   │   └── src/
 │   │       ├── cpu/
-│   │       │   ├── arm2.ts       # CPU core
+│   │       │   ├── arm2.ts       # CPU core + SWI passthrough mechanism
 │   │       │   └── registers.ts  # Register file (R0–R15, PSR)
 │   │       ├── memory/
 │   │       │   └── bus.ts        # System bus / address decode
 │   │       ├── chips/
-│   │       │   ├── memc.ts       # Memory controller
-│   │       │   ├── ioc.ts        # I/O controller
+│   │       │   ├── memc.ts       # Memory controller (CAM, ROM alias release)
+│   │       │   ├── ioc.ts        # I/O controller (timers, IRQ/FIQ, VBL)
 │   │       │   └── vidc.ts       # Video controller (stub)
-│   │       └── machine.ts        # Top-level machine wiring
+│   │       └── machine.ts        # Top-level machine wiring + bootROM()
 │   ├── risc-os/
 │   │   └── src/
 │   │       ├── swi/
-│   │       │   ├── dispatcher.ts # Registers all SWI handlers
+│   │       │   ├── dispatcher.ts # Registers Wimp + OS SWI handlers
 │   │       │   └── os-core.ts    # OS_* SWI implementations
 │   │       ├── fs/
 │   │       │   ├── fs-host.ts    # FileSystemHost interface
-│   │       │   └── os-fs.ts      # OS_File / OS_Find / OS_Args / OS_BGet / OS_BPut / OS_GBPB / OS_FSControl
+│   │       │   └── os-fs.ts      # HLE file SWI handlers (used in non-ROM mode)
 │   │       ├── wimp/
 │   │       │   ├── wimp-manager.ts  # Wimp_* SWI implementations
 │   │       │   ├── event-queue.ts   # Wimp event queue
@@ -248,9 +258,10 @@ acorn-desktop/
 │   └── electron-shell/
 │       └── src/
 │           ├── main/
-│           │   ├── index.ts            # Electron main process
+│           │   ├── index.ts            # Electron main process + boot sequence
 │           │   ├── native-wimp-host.ts # NativeHost → BrowserWindow
-│           │   ├── node-fs-host.ts     # FileSystemHost → host OS (~/Documents/RISCOS)
+│           │   ├── hostfs-handler.ts   # HostFS SWI handler (HostFS:: paths)
+│           │   ├── node-fs-host.ts     # FileSystemHost → host OS
 │           │   └── menu.ts             # Application menu
 │           ├── preload/
 │           │   ├── index.ts           # Launcher preload
@@ -266,12 +277,13 @@ acorn-desktop/
 
 ## ROM images
 
-You need a RISC OS ROM image to run anything. ROM images are copyrighted by RISC OS Open Ltd and are not included here. A legitimate copy can be obtained from [riscosopen.org](https://riscosopen.org).
+You need a RISC OS ROM image to run the emulator. ROM images are copyrighted by RISC OS Open Ltd and are not included here. A legitimate copy can be obtained from [riscosopen.org](https://riscosopen.org).
+
+Place the ROM image in `assets/roms/` with a `.rom`, `.bin`, or `.img` extension. The first file found is loaded automatically.
 
 ## Limitations
 
 - No VIDC pixel rendering — applications that draw directly to the frame buffer rather than using Wimp SWIs will not display correctly
 - No sound
-- Single-tasking (one ARM program at a time)
 - No floating-point emulation (FPE)
-- File system covers core I/O but not all `OS_FSControl` operations, `OS_Var`, or the FileSwitch module API
+- HostFS is read/write but does not implement all `OS_FSControl` operations or the full FileSwitch module registration API

--- a/packages/arm-emulator/src/chips/ioc.ts
+++ b/packages/arm-emulator/src/chips/ioc.ts
@@ -26,6 +26,9 @@
 export type IocIrqCallback = () => void;
 
 export class IOC {
+  // Control register (offset 0x00)
+  private control = 0xFF; // pull-ups give 0xFF on reset
+
   // Interrupt registers
   private irqAStatus  = 0x00;
   private irqARequest = 0x00;
@@ -71,6 +74,7 @@ export class IOC {
 
   read(offset: number): number {
     switch (offset & 0xFF) {
+      case 0x00: return this.control;
       case 0x10: return this.irqAStatus;
       case 0x14: { const r = this.irqARequest; this.irqARequest = 0; return r; }
       case 0x18: return this.irqAMask;
@@ -97,6 +101,7 @@ export class IOC {
 
   write(offset: number, value: number): void {
     switch (offset & 0xFF) {
+      case 0x00: this.control = value & 0xFF; break;
       case 0x18: this.irqAMask = value & 0xFF; break;
       case 0x28: this.irqBMask = value & 0xFF; break;
       case 0x38: this.fiqMask  = value & 0xFF; break;
@@ -169,7 +174,12 @@ export class IOC {
   }
 
   reset(): void {
-    this.irqAStatus = this.irqARequest = this.irqAMask = 0;
+    this.control    = 0xFF;
+    // Power-on reset: IRQA_POWER_ON is asserted so the ROM knows this is a
+    // cold start rather than a soft reset.
+    this.irqAStatus  = IOC.IRQA_POWER_ON;
+    this.irqARequest = IOC.IRQA_POWER_ON;
+    this.irqAMask    = 0;
     this.irqBStatus = this.irqBRequest = this.irqBMask = 0;
     this.fiqStatus  = this.fiqRequest  = this.fiqMask  = 0;
     this.timerLatch.fill(0);

--- a/packages/arm-emulator/src/chips/memc.ts
+++ b/packages/arm-emulator/src/chips/memc.ts
@@ -42,6 +42,13 @@ interface CamEntry {
 export class MEMC {
   control = 0;
 
+  /**
+   * Called once when the ROM alias should be released.
+   * The system bus sets this to clear its `romActive` flag.
+   * On real hardware any write to the MEMC control register removes the alias.
+   */
+  onRomAliasRelease?: () => void;
+
   /** Video DMA start address (physical) */
   videoDMAStart = 0x0200_0000;
   /** Video DMA end address (physical) */
@@ -94,6 +101,8 @@ export class MEMC {
   writeControl(offset: number, value: number): void {
     switch (offset & 0xFF) {
       case 0x00:
+        // Any write to the MEMC control register releases the ROM alias.
+        this.onRomAliasRelease?.();
         this.control = value;
         break;
       case 0x04:

--- a/packages/arm-emulator/src/cpu/arm2.ts
+++ b/packages/arm-emulator/src/cpu/arm2.ts
@@ -16,8 +16,13 @@ import { RegisterFile, Mode, PC_MASK, IRQ_MASK_BIT, FIQ_MASK_BIT } from "./regis
 import type { SystemBus } from "../memory/bus.js";
 import { Logger } from "@theprogramminggiantpanda/shared";
 
-/** A SWI handler receives the live register file and system bus. */
-export type SwiHandler = (regs: RegisterFile, bus: SystemBus) => void;
+/**
+ * A SWI handler receives the live register file and system bus.
+ * Returning `'passthrough'` causes the CPU to fall through to the ROM's own
+ * SWI vector, which is useful when a handler wants to service only a subset
+ * of calls (e.g. HostFS for "HostFS::" paths, ROM FileSwitch for everything else).
+ */
+export type SwiHandler = (regs: RegisterFile, bus: SystemBus) => 'passthrough' | void;
 
 /** Exception vector addresses (ARM2 standard) */
 const VECTOR_RESET   = 0x00000000;
@@ -425,10 +430,10 @@ export class ARM2CPU {
       this.logger.debug(`[SWI] 0x${swiNum.toString(16).padStart(6,'0')} ${tag}`);
     }
     if (handler) {
-      handler(this.regs, this.bus);
-    } else {
-      this.takeException(VECTOR_SWI, Mode.Supervisor);
+      const result = handler(this.regs, this.bus);
+      if (result !== 'passthrough') return;
     }
+    this.takeException(VECTOR_SWI, Mode.Supervisor);
   }
 
   /** Resume after an async SWI completes (called externally) */

--- a/packages/arm-emulator/src/cpu/arm2.ts
+++ b/packages/arm-emulator/src/cpu/arm2.ts
@@ -426,7 +426,7 @@ export class ARM2CPU {
     const handler = this.swiHandlers.get(swiNum);
     if (!this._swiSeen.has(swiNum)) {
       this._swiSeen.add(swiNum);
-      const tag = handler ? "handled" : "UNHANDLED";
+      const tag = handler ? "→JS" : "→ROM";
       this.logger.debug(`[SWI] 0x${swiNum.toString(16).padStart(6,'0')} ${tag}`);
     }
     if (handler) {

--- a/packages/arm-emulator/src/machine.ts
+++ b/packages/arm-emulator/src/machine.ts
@@ -27,10 +27,17 @@ export class ArchimedesMachine {
   private paused   = false;
   private tickHandle: ReturnType<typeof setTimeout> | null = null;
 
+  /** True when the real ROM has been booted (vs. bare-program HLE mode). */
+  romBooted = false;
+
   mhz = 0;
   private cycleSnapshot = 0;
   private lastMeasure   = 0;
   private _dataAbortCount = 0;
+
+  /** Accumulated emulated microseconds since last VBL — drives 50 Hz VBL IRQ. */
+  private vblAccumUs = 0;
+  private static readonly VBL_PERIOD_US = 20_000; // 50 Hz = 20 ms
 
   constructor(private readonly config: MachineConfig, private readonly logger = new Logger()) {
     this.memc = new MEMC();
@@ -110,6 +117,8 @@ export class ArchimedesMachine {
     this.cpu.reset();
     this.cycleSnapshot = 0;
     this.lastMeasure   = Date.now();
+    this.vblAccumUs    = 0;
+    this.romBooted     = false;
   }
 
   /**
@@ -135,28 +144,32 @@ export class ArchimedesMachine {
     // rather than returning ROM data. The ROM boot has already completed.
     this.bus.releaseROMAlias();
 
-    // Install minimal exception handlers at the physical RAM backing logical 0x00.
-    // The ROM relied on the ROM alias for exception handling; after releasing it,
-    // those vectors are zeros which cause infinite zero-RAM traversal on any fault.
-    // MOVS PC, R14 (0xE1B0F00E) = return from exception, skipping the faulted instr.
-    // B .         (0xEAFFFFFE) = infinite loop (halt) for vectors we never expect.
-    const vecPhys = this.memc.translateAddress(0);
-    if (vecPhys !== null) {
-      const MOVS_PC_R14 = 0xE1B0F00E;
-      const B_SELF      = 0xEAFFFFFE;
-      const writeVec = (logOff: number, instr: number) => {
-        this.bus.dmaWrite(vecPhys + logOff, new Uint8Array([
-          instr & 0xFF, (instr >>> 8) & 0xFF, (instr >>> 16) & 0xFF, (instr >>> 24) & 0xFF,
-        ]));
-      };
-      writeVec(0x00, B_SELF);       // Reset — should never fire
-      writeVec(0x04, B_SELF);       // Undefined instruction — halt
-      writeVec(0x08, MOVS_PC_R14); // SWI — return (our JS handler intercepts first)
-      writeVec(0x0C, MOVS_PC_R14); // Prefetch abort — skip
-      writeVec(0x10, MOVS_PC_R14); // Data abort — skip faulted instruction
-      writeVec(0x14, B_SELF);       // Reserved — halt
-      writeVec(0x18, MOVS_PC_R14); // IRQ — return
-      writeVec(0x1C, MOVS_PC_R14); // FIQ — return
+    // Install minimal exception handlers only in HLE mode (no ROM boot).
+    // When the real ROM has booted it programs its own vectors in RAM — we must
+    // not overwrite them or IRQ/SWI dispatch will break.
+    if (!this.romBooted) {
+      // The ROM relied on the ROM alias for exception handling; after releasing it,
+      // those vectors are zeros which cause infinite zero-RAM traversal on any fault.
+      // MOVS PC, R14 (0xE1B0F00E) = return from exception, skipping the faulted instr.
+      // B .         (0xEAFFFFFE) = infinite loop (halt) for vectors we never expect.
+      const vecPhys = this.memc.translateAddress(0);
+      if (vecPhys !== null) {
+        const MOVS_PC_R14 = 0xE1B0F00E;
+        const B_SELF      = 0xEAFFFFFE;
+        const writeVec = (logOff: number, instr: number) => {
+          this.bus.dmaWrite(vecPhys + logOff, new Uint8Array([
+            instr & 0xFF, (instr >>> 8) & 0xFF, (instr >>> 16) & 0xFF, (instr >>> 24) & 0xFF,
+          ]));
+        };
+        writeVec(0x00, B_SELF);       // Reset — should never fire
+        writeVec(0x04, B_SELF);       // Undefined instruction — halt
+        writeVec(0x08, MOVS_PC_R14); // SWI — return (our JS handler intercepts first)
+        writeVec(0x0C, MOVS_PC_R14); // Prefetch abort — skip
+        writeVec(0x10, MOVS_PC_R14); // Data abort — skip faulted instruction
+        writeVec(0x14, B_SELF);       // Reserved — halt
+        writeVec(0x18, MOVS_PC_R14); // IRQ — return
+        writeVec(0x1C, MOVS_PC_R14); // FIQ — return
+      }
     }
 
     this.bus.dmaWrite(writeDest, data);
@@ -189,6 +202,28 @@ export class ArchimedesMachine {
     this.running = true;
     this.paused  = false;
     this.reset();
+    this.scheduleTick();
+  }
+
+  /**
+   * Boot the machine by executing the loaded ROM from address 0.
+   *
+   * Unlike `start()` + `loadProgram()`, this does NOT install any HLE stubs at
+   * address 0 or release the ROM alias manually — the ROM itself releases the
+   * alias when it writes the MEMC control register.  SWI handlers registered
+   * via `registerSWI()` still intercept Wimp and OS SWIs before the ROM's own
+   * SWI vector is reached, so native-window Wimp rendering continues to work.
+   *
+   * A RISC OS ROM image must have been loaded with `loadROM()` before calling
+   * this method.
+   */
+  bootROM(): void {
+    this.running   = true;
+    this.paused    = false;
+    this.romBooted = true;
+    this.reset();
+    // reset() clears romBooted — re-assert it after reset.
+    this.romBooted = true;
     this.scheduleTick();
   }
 
@@ -230,7 +265,15 @@ export class ArchimedesMachine {
       this.running = false;
       return;
     }
-    this.ioc.tick(Math.floor((steps / clockHz) * 1_000_000));
+    const stepUs = Math.floor((steps / clockHz) * 1_000_000);
+    this.ioc.tick(stepUs);
+
+    // Fire vertical-blank interrupt at ~50 Hz so the ROM task switcher wakes.
+    this.vblAccumUs += stepUs;
+    if (this.vblAccumUs >= ArchimedesMachine.VBL_PERIOD_US) {
+      this.vblAccumUs -= ArchimedesMachine.VBL_PERIOD_US;
+      this.ioc.vblank();
+    }
 
     // MHz measurement
     const now = Date.now();

--- a/packages/arm-emulator/src/machine.ts
+++ b/packages/arm-emulator/src/machine.ts
@@ -218,11 +218,9 @@ export class ArchimedesMachine {
    * this method.
    */
   bootROM(): void {
+    this.reset();
     this.running   = true;
     this.paused    = false;
-    this.romBooted = true;
-    this.reset();
-    // reset() clears romBooted — re-assert it after reset.
     this.romBooted = true;
     this.scheduleTick();
   }

--- a/packages/arm-emulator/src/memory/bus.ts
+++ b/packages/arm-emulator/src/memory/bus.ts
@@ -49,6 +49,8 @@ export class SystemBus {
   ) {
     this.ram = new Uint8Array(ramBytes);
     this.rom = new Uint8Array(0); // loaded via loadROM()
+    // Release ROM alias automatically when the ROM writes the MEMC control reg.
+    this.memc.onRomAliasRelease = () => { this.romActive = false; };
   }
 
   loadROM(data: Uint8Array): void {

--- a/packages/electron-shell/src/main/hostfs-handler.ts
+++ b/packages/electron-shell/src/main/hostfs-handler.ts
@@ -26,6 +26,44 @@ const SWI_OS_FSCONTROL = 0x19;
 // RISC OS file attributes: public-read | owner-read | owner-write
 const ATTR_DEFAULT = 0x03;
 
+// ---------------------------------------------------------------------------
+// File type helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a RISC OS `,xyz` filetype suffix from a host filename.
+ * e.g. "Document,ffc" → { baseName: "Document", fileType: 0xFFC }
+ *      "!Run"         → { baseName: "!Run",      fileType: null }
+ */
+function parseTypeSuffix(hostName: string): { baseName: string; fileType: number | null } {
+  const match = /^(.+),([0-9a-fA-F]{3})$/.exec(hostName);
+  if (match) return { baseName: match[1]!, fileType: parseInt(match[2]!, 16) };
+  return { baseName: hostName, fileType: null };
+}
+
+/**
+ * Convert a host file's mtime (ms since 1970 Unix epoch) to the pair of
+ * words used in a RISC OS typed-file load/exec encoding:
+ *
+ *   load = 0xFFFtttHH  (ttt = 12-bit type, HH = top byte of 5-byte timestamp)
+ *   exec = LLLLLLLL    (low 4 bytes of the 5-byte centisecond timestamp)
+ *
+ * The RISC OS epoch is 1 January 1900; the timestamp is centiseconds.
+ */
+function makeLoadExec(fileType: number, mtimeMs: number): { load: number; exec: number } {
+  // Centiseconds from 1900-01-01 to 1970-01-01 (70 years + 17 leap days)
+  const EPOCH_OFFSET_CS = 220_898_880_000n;
+  const cs    = BigInt(Math.floor(mtimeMs / 10)) + EPOCH_OFFSET_CS;
+  const csHi  = Number((cs >> 32n) & 0xFFn);   // top byte of 5-byte stamp
+  const csLo  = Number(cs & 0xFFFF_FFFFn);       // lower 4 bytes
+  const load  = (0xFFF00000 | ((fileType & 0xFFF) << 8) | csHi) >>> 0;
+  return { load, exec: csLo >>> 0 };
+}
+
+/** Default load/exec for a file with no known type (untyped, no timestamp). */
+const UNTYPED_LOAD = 0xFFFFFFFF;
+const UNTYPED_EXEC = 0x00000000;
+
 interface HandleEntry {
   type:       "file" | "dir";
   nativePath: string;
@@ -45,23 +83,6 @@ export class HostFsHandler {
   // ---------------------------------------------------------------------------
   // Path translation
   // ---------------------------------------------------------------------------
-
-  /** Returns the native path for a "HostFS::" RISC OS path, or null if not ours. */
-  private toNative(riscosPath: string): string | null {
-    if (!riscosPath.toLowerCase().startsWith("hostfs::")) return null;
-    const inner = riscosPath.slice(8); // strip "HostFS::"
-    let relative: string;
-    if (inner === "$" || inner === "$.") {
-      relative = "";
-    } else if (inner.startsWith("$.")) {
-      // Replace RISC OS "." separator with native separator
-      relative = inner.slice(2).split(".").join(path.sep);
-    } else {
-      // No $ prefix — treat as relative to root
-      relative = inner.split(".").join(path.sep);
-    }
-    return path.join(this.root, relative);
-  }
 
   // ---------------------------------------------------------------------------
   // Helpers
@@ -99,6 +120,53 @@ export class HostFsHandler {
     return stat.isDirectory() ? 2 : 1;
   }
 
+  /**
+   * Resolve a RISC OS leaf name (no `,xyz` suffix) to the actual host filename
+   * inside `dir`.  If a file exists with a `,xyz` suffix it takes precedence;
+   * otherwise the bare name is returned (which may or may not exist).
+   */
+  private resolveLeaf(dir: string, riscosLeaf: string): string {
+    // Try exact match first (covers directories and untyped files)
+    const exact = path.join(dir, riscosLeaf);
+    try { fs.statSync(exact); return exact; } catch { /* try typed suffix */ }
+
+    // Scan directory for a file with the same base name + ,xyz suffix
+    try {
+      const entries = fs.readdirSync(dir);
+      const lowerLeaf = riscosLeaf.toLowerCase();
+      for (const entry of entries) {
+        const { baseName } = parseTypeSuffix(entry);
+        if (baseName.toLowerCase() === lowerLeaf) return path.join(dir, entry);
+      }
+    } catch { /* fall through */ }
+
+    return exact; // not found either way — return bare path (caller handles error)
+  }
+
+  /**
+   * Translate a RISC OS HostFS path to the actual native path, resolving each
+   * component through `resolveLeaf` so that `,xyz`-suffixed files are found
+   * transparently.
+   */
+  private toNativeResolved(riscosPath: string): string | null {
+    if (!riscosPath.toLowerCase().startsWith("hostfs::")) return null;
+    const inner = riscosPath.slice(8);
+    let components: string[];
+    if (inner === "$" || inner === "$.") {
+      return this.root;
+    } else if (inner.startsWith("$.")) {
+      components = inner.slice(2).split(".");
+    } else {
+      components = inner.split(".");
+    }
+
+    let current = this.root;
+    for (const comp of components) {
+      current = this.resolveLeaf(current, comp);
+    }
+    return current;
+  }
+
   // ---------------------------------------------------------------------------
   // OS_File (SWI 0x08)
   // ---------------------------------------------------------------------------
@@ -107,7 +175,7 @@ export class HostFsHandler {
     const reason   = regs.read(0);
     const pathAddr = regs.read(1) >>> 0;
     const riscPath = this.readString(bus, pathAddr);
-    const native   = this.toNative(riscPath);
+    const native   = this.toNativeResolved(riscPath);
     if (native === null) return "passthrough";
 
     regs.V = false;
@@ -116,9 +184,16 @@ export class HostFsHandler {
       case 5: { // Read catalogue info
         try {
           const stat = fs.statSync(native);
+          const { baseName: _, fileType } = parseTypeSuffix(path.basename(native));
+          let load: number, exec: number;
+          if (fileType !== null) {
+            ({ load, exec } = makeLoadExec(fileType, stat.mtimeMs));
+          } else {
+            load = UNTYPED_LOAD; exec = UNTYPED_EXEC;
+          }
           regs.write(0, this.statToType(stat)); // 1=file, 2=dir
-          regs.write(2, 0xFFFFFFFF);            // load addr (untyped)
-          regs.write(3, 0x00000000);            // exec addr
+          regs.write(2, load);
+          regs.write(3, exec);
           regs.write(4, stat.isFile() ? stat.size : 0);
           regs.write(5, ATTR_DEFAULT);
         } catch {
@@ -135,11 +210,19 @@ export class HostFsHandler {
       case 255: { // Load file to address in R2
         const destAddr = regs.read(2) >>> 0;
         try {
+          const stat = fs.statSync(native);
+          const { fileType } = parseTypeSuffix(path.basename(native));
+          let load: number, exec: number;
+          if (fileType !== null) {
+            ({ load, exec } = makeLoadExec(fileType, stat.mtimeMs));
+          } else {
+            load = UNTYPED_LOAD; exec = UNTYPED_EXEC;
+          }
           const data = fs.readFileSync(native);
           bus.dmaWrite(destAddr, data);
-          regs.write(0, 1);           // type = file
-          regs.write(2, destAddr);
-          regs.write(3, 0);
+          regs.write(0, 1);
+          regs.write(2, load);
+          regs.write(3, exec);
           regs.write(4, data.length);
           regs.write(5, ATTR_DEFAULT);
         } catch {
@@ -179,7 +262,7 @@ export class HostFsHandler {
     // Open: R0 bits[7:4]=mode (0x40=read, 0x80=write, 0xC0=update), R1=path
     const pathAddr = regs.read(1) >>> 0;
     const riscPath = this.readString(bus, pathAddr);
-    const native   = this.toNative(riscPath);
+    const native   = this.toNativeResolved(riscPath);
     if (native === null) return "passthrough";
 
     try {
@@ -230,7 +313,7 @@ export class HostFsHandler {
     if (reason >= 9 && reason <= 12) {
       const pathAddr = regs.read(1) >>> 0;
       const riscPath = this.readString(bus, pathAddr);
-      const native   = this.toNative(riscPath);
+      const native   = this.toNativeResolved(riscPath);
       if (native === null) return "passthrough";
 
       const bufAddr  = regs.read(2) >>> 0;
@@ -247,13 +330,16 @@ export class HostFsHandler {
       let idx     = startIdx;
 
       while (written < maxCount && idx < allEntries.length) {
-        const name      = allEntries[idx]!;
-        const entryPath = path.join(native, name);
+        const hostName  = allEntries[idx]!;
+        const entryPath = path.join(native, hostName);
         let stat: fs.Stats;
         try { stat = fs.statSync(entryPath); } catch { idx++; continue; }
 
+        // Strip ,xyz suffix — present the bare name to RISC OS
+        const { baseName, fileType } = parseTypeSuffix(hostName);
+
         // Calculate entry size before writing to check buffer bounds
-        const nameBytes = name.length + 1; // with null terminator
+        const nameBytes = baseName.length + 1; // with null terminator
         const namePad   = (nameBytes + 3) & ~3;
         const infoSize  = reason >= 10 ? 20 : 0; // 5 words of info for reasons 10+
         const entrySize = infoSize + namePad;
@@ -262,16 +348,22 @@ export class HostFsHandler {
 
         if (reason >= 10) {
           // Load addr, exec addr, size, attrs, type (5 words)
-          bus.write32(ptr,      0xFFFFFFFF);  // load addr (untyped)
-          bus.write32(ptr + 4,  0x00000000);  // exec addr
+          let load: number, exec: number;
+          if (fileType !== null) {
+            ({ load, exec } = makeLoadExec(fileType, stat.mtimeMs));
+          } else {
+            load = UNTYPED_LOAD; exec = UNTYPED_EXEC;
+          }
+          bus.write32(ptr,      load);
+          bus.write32(ptr + 4,  exec);
           bus.write32(ptr + 8,  stat.isFile() ? stat.size : 0);
           bus.write32(ptr + 12, ATTR_DEFAULT);
           bus.write32(ptr + 16, stat.isDirectory() ? 2 : 1); // object type
           ptr += 20;
         }
 
-        // Write name + null, padded to word
-        const len = this.writeString(bus, ptr, name);
+        // Write bare name + null, padded to word
+        const len = this.writeString(bus, ptr, baseName);
         for (let p = len; p < namePad; p++) bus.write8(ptr + p, 0);
         ptr += namePad;
 
@@ -339,7 +431,7 @@ export class HostFsHandler {
         const dstAddr  = regs.read(2) >>> 0;
         const dstLen   = regs.read(5) >>> 0;
         const src      = this.readString(bus, srcAddr);
-        if (this.toNative(src) === null) return "passthrough";
+        if (this.toNativeResolved(src) === null) return "passthrough";
         if (dstAddr && dstLen) {
           this.writeString(bus, dstAddr, src.slice(0, dstLen - 1));
         }

--- a/packages/electron-shell/src/main/hostfs-handler.ts
+++ b/packages/electron-shell/src/main/hostfs-handler.ts
@@ -1,0 +1,365 @@
+/**
+ * HostFS SWI Handler
+ *
+ * Intercepts OS_File, OS_Find, OS_Args, OS_GBPB, OS_FSControl for paths that
+ * begin with "HostFS::" and maps them onto the host filesystem via Node.js fs.
+ * All other paths return 'passthrough' so the real ROM FileSwitch handles them.
+ *
+ * File handles 200–254 are reserved for HostFS to avoid colliding with the
+ * ROM's own handle allocation (typically 1–127).
+ *
+ * RISC OS path format:  HostFS::$.dir.subdir.file
+ * Host path format:     {rootDir}/dir/subdir/file
+ */
+
+import fs from "fs";
+import path from "path";
+import type { RegisterFile, ArchimedesMachine } from "@theprogramminggiantpanda/arm-emulator";
+import type { SystemBus } from "@theprogramminggiantpanda/arm-emulator";
+
+const SWI_OS_FILE      = 0x08;
+const SWI_OS_ARGS      = 0x09;
+const SWI_OS_GBPB      = 0x0C;
+const SWI_OS_FIND      = 0x0D;
+const SWI_OS_FSCONTROL = 0x19;
+
+// RISC OS file attributes: public-read | owner-read | owner-write
+const ATTR_DEFAULT = 0x03;
+
+interface HandleEntry {
+  type:       "file" | "dir";
+  nativePath: string;
+  offset:     number;
+  size:       number;
+}
+
+export class HostFsHandler {
+  private readonly root: string;
+  private readonly handles = new Map<number, HandleEntry>();
+  private nextHandle = 200;
+
+  constructor(rootDir: string) {
+    this.root = path.resolve(rootDir);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Path translation
+  // ---------------------------------------------------------------------------
+
+  /** Returns the native path for a "HostFS::" RISC OS path, or null if not ours. */
+  private toNative(riscosPath: string): string | null {
+    if (!riscosPath.toLowerCase().startsWith("hostfs::")) return null;
+    const inner = riscosPath.slice(8); // strip "HostFS::"
+    let relative: string;
+    if (inner === "$" || inner === "$.") {
+      relative = "";
+    } else if (inner.startsWith("$.")) {
+      // Replace RISC OS "." separator with native separator
+      relative = inner.slice(2).split(".").join(path.sep);
+    } else {
+      // No $ prefix — treat as relative to root
+      relative = inner.split(".").join(path.sep);
+    }
+    return path.join(this.root, relative);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  private allocHandle(): number {
+    const start = this.nextHandle;
+    // Find the next free handle in the 200–254 range
+    while (this.handles.has(this.nextHandle)) {
+      this.nextHandle = this.nextHandle >= 254 ? 200 : this.nextHandle + 1;
+      if (this.nextHandle === start) throw new Error("HostFS: out of file handles");
+    }
+    const h = this.nextHandle;
+    this.nextHandle = this.nextHandle >= 254 ? 200 : this.nextHandle + 1;
+    return h;
+  }
+
+  private readString(bus: SystemBus, addr: number, maxLen = 512): string {
+    let s = "";
+    for (let i = 0; i < maxLen; i++) {
+      const ch = bus.read8(addr + i);
+      if (ch === 0 || ch === 13) break; // null or CR terminates
+      s += String.fromCharCode(ch);
+    }
+    return s;
+  }
+
+  private writeString(bus: SystemBus, addr: number, s: string): number {
+    for (let i = 0; i < s.length; i++) bus.write8(addr + i, s.charCodeAt(i));
+    bus.write8(addr + s.length, 0);
+    return s.length + 1;
+  }
+
+  private statToType(stat: fs.Stats): 1 | 2 {
+    return stat.isDirectory() ? 2 : 1;
+  }
+
+  // ---------------------------------------------------------------------------
+  // OS_File (SWI 0x08)
+  // ---------------------------------------------------------------------------
+
+  private handleOsFile(regs: RegisterFile, bus: SystemBus): "passthrough" | void {
+    const reason   = regs.read(0);
+    const pathAddr = regs.read(1) >>> 0;
+    const riscPath = this.readString(bus, pathAddr);
+    const native   = this.toNative(riscPath);
+    if (native === null) return "passthrough";
+
+    regs.V = false;
+
+    switch (reason) {
+      case 5: { // Read catalogue info
+        try {
+          const stat = fs.statSync(native);
+          regs.write(0, this.statToType(stat)); // 1=file, 2=dir
+          regs.write(2, 0xFFFFFFFF);            // load addr (untyped)
+          regs.write(3, 0x00000000);            // exec addr
+          regs.write(4, stat.isFile() ? stat.size : 0);
+          regs.write(5, ATTR_DEFAULT);
+        } catch {
+          regs.write(0, 0); // not found
+        }
+        break;
+      }
+
+      case 8: // Create directory
+        try { fs.mkdirSync(native, { recursive: true }); } catch { /* ignore */ }
+        regs.write(0, 2);
+        break;
+
+      case 255: { // Load file to address in R2
+        const destAddr = regs.read(2) >>> 0;
+        try {
+          const data = fs.readFileSync(native);
+          bus.dmaWrite(destAddr, data);
+          regs.write(0, 1);           // type = file
+          regs.write(2, destAddr);
+          regs.write(3, 0);
+          regs.write(4, data.length);
+          regs.write(5, ATTR_DEFAULT);
+        } catch {
+          regs.write(0, 0);
+        }
+        break;
+      }
+
+      default:
+        regs.write(0, 0);
+        break;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // OS_Find (SWI 0x0D)
+  // ---------------------------------------------------------------------------
+
+  private handleOsFind(regs: RegisterFile, bus: SystemBus): "passthrough" | void {
+    const reason = regs.read(0) & 0xFF;
+    regs.V = false;
+
+    if (reason === 0) {
+      // Close: R1 = handle (0 = close all HostFS handles)
+      const handle = regs.read(1);
+      if (handle === 0) {
+        this.handles.clear();
+        return "passthrough"; // also let ROM close its own handles
+      }
+      if (this.handles.has(handle)) {
+        this.handles.delete(handle);
+        return; // handled — don't touch ROM
+      }
+      return "passthrough"; // not our handle
+    }
+
+    // Open: R0 bits[7:4]=mode (0x40=read, 0x80=write, 0xC0=update), R1=path
+    const pathAddr = regs.read(1) >>> 0;
+    const riscPath = this.readString(bus, pathAddr);
+    const native   = this.toNative(riscPath);
+    if (native === null) return "passthrough";
+
+    try {
+      const stat = fs.statSync(native);
+      const h    = this.allocHandle();
+      this.handles.set(h, {
+        type:       this.statToType(stat) === 2 ? "dir" : "file",
+        nativePath: native,
+        offset:     0,
+        size:       stat.isFile() ? stat.size : 0,
+      });
+      regs.write(0, h);
+    } catch {
+      regs.write(0, 0); // file not found
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // OS_Args (SWI 0x09)
+  // ---------------------------------------------------------------------------
+
+  private handleOsArgs(regs: RegisterFile, bus: SystemBus): "passthrough" | void {
+    const reason = regs.read(0);
+    const handle = regs.read(1);
+    const entry  = this.handles.get(handle);
+    if (!entry) return "passthrough";
+
+    regs.V = false;
+    switch (reason) {
+      case 0: regs.write(2, entry.offset); break;             // read ptr
+      case 1: entry.offset = regs.read(2) >>> 0; break;       // set ptr
+      case 2: regs.write(2, entry.size);   break;             // read extent
+      case 255: /* flush — no-op for read-only */ break;
+      default: regs.write(2, 0); break;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // OS_GBPB (SWI 0x0C)
+  // ---------------------------------------------------------------------------
+
+  private handleOsGBPB(regs: RegisterFile, bus: SystemBus): "passthrough" | void {
+    const reason = regs.read(0);
+    regs.V = false;
+
+    // ── Directory enumeration (reasons 9, 10, 11, 12) ────────────────────────
+    // R1 = path ptr, R2 = buf addr, R3 = max entries, R4 = start index, R5 = buf len
+    if (reason >= 9 && reason <= 12) {
+      const pathAddr = regs.read(1) >>> 0;
+      const riscPath = this.readString(bus, pathAddr);
+      const native   = this.toNative(riscPath);
+      if (native === null) return "passthrough";
+
+      const bufAddr  = regs.read(2) >>> 0;
+      const maxCount = regs.read(3) >>> 0;
+      const startIdx = regs.read(4) >>> 0;
+      const bufLen   = regs.read(5) >>> 0;
+
+      let allEntries: string[];
+      try { allEntries = fs.readdirSync(native).sort(); }
+      catch { regs.write(3, 0); regs.write(4, 0xFFFFFFFF); return; }
+
+      let ptr     = bufAddr;
+      let written = 0;
+      let idx     = startIdx;
+
+      while (written < maxCount && idx < allEntries.length) {
+        const name      = allEntries[idx]!;
+        const entryPath = path.join(native, name);
+        let stat: fs.Stats;
+        try { stat = fs.statSync(entryPath); } catch { idx++; continue; }
+
+        // Calculate entry size before writing to check buffer bounds
+        const nameBytes = name.length + 1; // with null terminator
+        const namePad   = (nameBytes + 3) & ~3;
+        const infoSize  = reason >= 10 ? 20 : 0; // 5 words of info for reasons 10+
+        const entrySize = infoSize + namePad;
+
+        if (ptr + entrySize > bufAddr + bufLen) break;
+
+        if (reason >= 10) {
+          // Load addr, exec addr, size, attrs, type (5 words)
+          bus.write32(ptr,      0xFFFFFFFF);  // load addr (untyped)
+          bus.write32(ptr + 4,  0x00000000);  // exec addr
+          bus.write32(ptr + 8,  stat.isFile() ? stat.size : 0);
+          bus.write32(ptr + 12, ATTR_DEFAULT);
+          bus.write32(ptr + 16, stat.isDirectory() ? 2 : 1); // object type
+          ptr += 20;
+        }
+
+        // Write name + null, padded to word
+        const len = this.writeString(bus, ptr, name);
+        for (let p = len; p < namePad; p++) bus.write8(ptr + p, 0);
+        ptr += namePad;
+
+        written++;
+        idx++;
+      }
+
+      regs.write(3, written);
+      regs.write(4, idx >= allEntries.length ? 0xFFFFFFFF : idx);
+      return;
+    }
+
+    // ── Sequential file read (reasons 3, 4) ──────────────────────────────────
+    if (reason === 3 || reason === 4) {
+      const handle  = regs.read(1);
+      const bufAddr = regs.read(2) >>> 0;
+      let   count   = regs.read(3) >>> 0;
+      const entry   = this.handles.get(handle);
+      if (!entry || entry.type !== "file") return "passthrough";
+
+      let readAt: number;
+      if (reason === 3) {
+        readAt = regs.read(4) >>> 0;
+      } else {
+        readAt = entry.offset;
+      }
+
+      let data: Buffer;
+      try { data = fs.readFileSync(entry.nativePath); }
+      catch { regs.write(3, count); return; }
+
+      const avail  = Math.max(0, data.length - readAt);
+      const toRead = Math.min(count, avail);
+      bus.dmaWrite(bufAddr, new Uint8Array(data.buffer, readAt, toRead));
+
+      entry.offset = readAt + toRead;
+      count -= toRead;
+      regs.write(3, count);
+      if (reason === 3) regs.write(4, readAt + toRead);
+      return;
+    }
+
+    return "passthrough";
+  }
+
+  // ---------------------------------------------------------------------------
+  // OS_FSControl (SWI 0x19)
+  // ---------------------------------------------------------------------------
+
+  private handleOsFsControl(regs: RegisterFile, bus: SystemBus): "passthrough" | void {
+    const reason = regs.read(0);
+    regs.V = false;
+
+    switch (reason) {
+      case 0: { // Select filing system — if "HostFS" is selected, acknowledge
+        const nameAddr = regs.read(1) >>> 0;
+        if (nameAddr) {
+          const name = this.readString(bus, nameAddr);
+          if (name.toLowerCase() === "hostfs") return; // handled
+        }
+        return "passthrough";
+      }
+      case 36: { // Canonicalise path
+        const srcAddr  = regs.read(1) >>> 0;
+        const dstAddr  = regs.read(2) >>> 0;
+        const dstLen   = regs.read(5) >>> 0;
+        const src      = this.readString(bus, srcAddr);
+        if (this.toNative(src) === null) return "passthrough";
+        if (dstAddr && dstLen) {
+          this.writeString(bus, dstAddr, src.slice(0, dstLen - 1));
+        }
+        regs.write(5, Math.max(0, src.length + 1 - (dstLen || 0)));
+        break;
+      }
+      default:
+        return "passthrough";
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Register all handlers on the machine
+  // ---------------------------------------------------------------------------
+
+  register(machine: ArchimedesMachine): void {
+    machine.registerSWI(SWI_OS_FILE,      (r, b) => this.handleOsFile(r, b));
+    machine.registerSWI(SWI_OS_FIND,      (r, b) => this.handleOsFind(r, b));
+    machine.registerSWI(SWI_OS_ARGS,      (r, b) => this.handleOsArgs(r, b));
+    machine.registerSWI(SWI_OS_GBPB,      (r, b) => this.handleOsGBPB(r, b));
+    machine.registerSWI(SWI_OS_FSCONTROL, (r, b) => this.handleOsFsControl(r, b));
+  }
+}

--- a/packages/electron-shell/src/main/hostfs-handler.ts
+++ b/packages/electron-shell/src/main/hostfs-handler.ts
@@ -223,7 +223,7 @@ export class HostFsHandler {
         const start    = regs.read(4) >>> 0;
         const end      = regs.read(5) >>> 0;
         const fileType = extractFileType(loadAddr);
-        const leaf     = path.basename(native);
+        const leaf     = parseTypeSuffix(path.basename(native)).baseName;
         const dir      = path.dirname(native);
         const savePath = this.saveNativePath(dir, leaf, fileType);
         const len      = end > start ? end - start : 0;
@@ -562,5 +562,9 @@ export class HostFsHandler {
     machine.registerSWI(SWI_OS_ARGS,      (r, b) => this.handleOsArgs(r, b));
     machine.registerSWI(SWI_OS_GBPB,      (r, b) => this.handleOsGBPB(r, b));
     machine.registerSWI(SWI_OS_FSCONTROL, (r, b) => this.handleOsFsControl(r, b));
+    // TODO: intercept OS_BGet (0x0A) and OS_BPut (0x0B) for HostFS handles 200–254.
+    // Currently those SWIs fall through to the ROM's FileSwitch, which won't recognise
+    // our handle numbers.  In practice apps use GBPB for bulk I/O so this rarely bites,
+    // but single-byte reads/writes to HostFS handles will silently fail until fixed.
   }
 }

--- a/packages/electron-shell/src/main/hostfs-handler.ts
+++ b/packages/electron-shell/src/main/hostfs-handler.ts
@@ -64,11 +64,24 @@ function makeLoadExec(fileType: number, mtimeMs: number): { load: number; exec: 
 const UNTYPED_LOAD = 0xFFFFFFFF;
 const UNTYPED_EXEC = 0x00000000;
 
+/**
+ * Extract the 12-bit RISC OS file type from a typed load address
+ * (bits [23:20] = 0xF → typed file; bits [19:8] = type).
+ * Returns null for untyped load addresses.
+ */
+function extractFileType(loadAddr: number): number | null {
+  return ((loadAddr >>> 20) & 0xFFF) === 0xFFF
+    ? (loadAddr >>> 8) & 0xFFF
+    : null;
+}
+
 interface HandleEntry {
   type:       "file" | "dir";
   nativePath: string;
   offset:     number;
   size:       number;
+  /** Set for writable handles; accumulated in memory and flushed on close. */
+  writeBuf?:  number[];
 }
 
 export class HostFsHandler {
@@ -118,6 +131,29 @@ export class HostFsHandler {
 
   private statToType(stat: fs.Stats): 1 | 2 {
     return stat.isDirectory() ? 2 : 1;
+  }
+
+  /**
+   * Return the host path to write to for a given RISC OS leaf name + file type.
+   * Appends `,xyz` when fileType is known, and removes any existing file in the
+   * same directory that has the same base name with a *different* `,xyz` suffix
+   * (RISC OS re-typing a file should not leave an orphaned copy behind).
+   */
+  private saveNativePath(dir: string, riscosLeaf: string, fileType: number | null): string {
+    const suffix  = fileType !== null ? `,${fileType.toString(16).padStart(3, "0")}` : "";
+    const newName = riscosLeaf + suffix;
+
+    // Remove stale ,xyz copies with a different suffix
+    try {
+      for (const entry of fs.readdirSync(dir)) {
+        const { baseName } = parseTypeSuffix(entry);
+        if (baseName.toLowerCase() === riscosLeaf.toLowerCase() && entry !== newName) {
+          try { fs.unlinkSync(path.join(dir, entry)); } catch { /* ignore */ }
+        }
+      }
+    } catch { /* dir unreadable — ignore */ }
+
+    return path.join(dir, newName);
   }
 
   /**
@@ -181,6 +217,32 @@ export class HostFsHandler {
     regs.V = false;
 
     switch (reason) {
+      case 0: { // Save memory block to file
+        // R1=name, R2=load addr (may encode type), R3=exec addr, R4=start, R5=end
+        const loadAddr = regs.read(2) >>> 0;
+        const start    = regs.read(4) >>> 0;
+        const end      = regs.read(5) >>> 0;
+        const fileType = extractFileType(loadAddr);
+        const leaf     = path.basename(native);
+        const dir      = path.dirname(native);
+        const savePath = this.saveNativePath(dir, leaf, fileType);
+        const len      = end > start ? end - start : 0;
+        const data     = new Uint8Array(len);
+        for (let i = 0; i < len; i++) data[i] = bus.read8(start + i);
+        try {
+          fs.mkdirSync(dir, { recursive: true });
+          fs.writeFileSync(savePath, data);
+          regs.write(0, 1); // type = file
+          regs.write(2, loadAddr);
+          regs.write(3, regs.read(3)); // preserve exec addr
+          regs.write(4, len);
+          regs.write(5, ATTR_DEFAULT);
+        } catch {
+          regs.write(0, 0);
+        }
+        break;
+      }
+
       case 5: { // Read catalogue info
         try {
           const stat = fs.statSync(native);
@@ -249,10 +311,13 @@ export class HostFsHandler {
       // Close: R1 = handle (0 = close all HostFS handles)
       const handle = regs.read(1);
       if (handle === 0) {
+        for (const entry of this.handles.values()) this.flushHandle(entry);
         this.handles.clear();
         return "passthrough"; // also let ROM close its own handles
       }
       if (this.handles.has(handle)) {
+        const entry = this.handles.get(handle)!;
+        this.flushHandle(entry);
         this.handles.delete(handle);
         return; // handled — don't touch ROM
       }
@@ -260,24 +325,43 @@ export class HostFsHandler {
     }
 
     // Open: R0 bits[7:4]=mode (0x40=read, 0x80=write, 0xC0=update), R1=path
+    const mode     = reason & 0xF0;
     const pathAddr = regs.read(1) >>> 0;
     const riscPath = this.readString(bus, pathAddr);
     const native   = this.toNativeResolved(riscPath);
     if (native === null) return "passthrough";
 
     try {
-      const stat = fs.statSync(native);
-      const h    = this.allocHandle();
+      const writable = mode === 0x80 || mode === 0xC0;
+      let existingData: number[] = [];
+      let size = 0;
+      try {
+        const buf  = fs.readFileSync(native);
+        existingData = Array.from(buf);
+        size = buf.length;
+      } catch {
+        // New file — start empty (write mode)
+        if (!writable) { regs.write(0, 0); return; }
+      }
+      const h = this.allocHandle();
       this.handles.set(h, {
-        type:       this.statToType(stat) === 2 ? "dir" : "file",
+        type:      "file",
         nativePath: native,
-        offset:     0,
-        size:       stat.isFile() ? stat.size : 0,
+        offset:    0,
+        size,
+        writeBuf:  writable ? existingData : undefined,
       });
       regs.write(0, h);
     } catch {
       regs.write(0, 0); // file not found
     }
+  }
+
+  /** Flush a writable handle's write buffer to disk. */
+  private flushHandle(entry: HandleEntry): void {
+    if (!entry.writeBuf) return;
+    try { fs.writeFileSync(entry.nativePath, Buffer.from(entry.writeBuf)); }
+    catch { /* best-effort */ }
   }
 
   // ---------------------------------------------------------------------------
@@ -295,7 +379,7 @@ export class HostFsHandler {
       case 0: regs.write(2, entry.offset); break;             // read ptr
       case 1: entry.offset = regs.read(2) >>> 0; break;       // set ptr
       case 2: regs.write(2, entry.size);   break;             // read extent
-      case 255: /* flush — no-op for read-only */ break;
+      case 255: this.flushHandle(entry); break;
       default: regs.write(2, 0); break;
     }
   }
@@ -373,6 +457,31 @@ export class HostFsHandler {
 
       regs.write(3, written);
       regs.write(4, idx >= allEntries.length ? 0xFFFFFFFF : idx);
+      return;
+    }
+
+    // ── Sequential file write (reasons 1, 2) ─────────────────────────────────
+    if (reason === 1 || reason === 2) {
+      const handle  = regs.read(1);
+      const bufAddr = regs.read(2) >>> 0;
+      const count   = regs.read(3) >>> 0;
+      const entry   = this.handles.get(handle);
+      if (!entry || !entry.writeBuf) return "passthrough";
+
+      const writeAt = reason === 1 ? regs.read(4) >>> 0 : entry.offset;
+
+      // Extend the write buffer if needed
+      const needed = writeAt + count;
+      while (entry.writeBuf.length < needed) entry.writeBuf.push(0);
+      for (let i = 0; i < count; i++) {
+        entry.writeBuf[writeAt + i] = bus.read8(bufAddr + i);
+      }
+      entry.offset = writeAt + count;
+      entry.size   = Math.max(entry.size, entry.offset);
+
+      regs.write(2, bufAddr + count);
+      regs.write(3, 0); // zero bytes remaining
+      if (reason === 1) regs.write(4, entry.offset);
       return;
     }
 

--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -71,7 +71,7 @@ function createLauncherWindow(): BrowserWindow {
 
   if (isDev) {
     win.loadURL("http://localhost:5173/index.html");
-    win.webContents.openDevTools({ mode: "detach" });
+    win.webContents.openDevTools({ mode: "bottom" });
   } else {
     win.loadFile(path.join(__dirname, "../../renderer/index.html"));
   }
@@ -151,7 +151,7 @@ function createProgramsBrowserWindow(): BrowserWindow {
 
   if (isDev) {
     win.loadURL("http://localhost:5173/programs-browser.html");
-    win.webContents.once("did-finish-load", () => win.webContents.openDevTools({ mode: "detach" }));
+    win.webContents.once("did-finish-load", () => win.webContents.openDevTools({ mode: "bottom" }));
   } else {
     win.loadFile(path.join(__dirname, "../../renderer/programs-browser.html"));
   }

--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -12,6 +12,7 @@ import { ArchimedesMachine } from "@theprogramminggiantpanda/arm-emulator";
 import { SwiDispatcher, ObeyInterpreter, SpritePool } from "@theprogramminggiantpanda/risc-os";
 import { NativeWimpHost } from "./native-wimp-host.js";
 import { NodeFsHost } from "./node-fs-host.js";
+import { HostFsHandler } from "./hostfs-handler.js";
 import { buildAppMenu } from "./menu.js";
 import type { MachineConfig, AppEntry } from "@theprogramminggiantpanda/shared";
 import { IPC, Logger } from "@theprogramminggiantpanda/shared";
@@ -215,12 +216,13 @@ function startMachine(romData: Uint8Array, appHostPath?: string): void {
 
   machine    = new ArchimedesMachine(config, logger);
   wimpHost   = new NativeWimpHost();
+  // In ROM boot mode the real OS handles all non-HostFS file SWIs; we skip
+  // the HLE `fs` option so the dispatcher does not register competing handlers.
   dispatcher = new SwiDispatcher(machine, wimpHost, {
     onOutput: (text) => {
       logger.debug(`[RISC OS] ${text}`);
       launcherWindow?.webContents.send("console-output", text);
     },
-    fs: nodeFs,
     onRunBinary: (riscosPath) => {
       logger.debug(`[onRunBinary] loading: ${riscosPath}`);
       try {
@@ -239,6 +241,11 @@ function startMachine(romData: Uint8Array, appHostPath?: string): void {
       }
     },
   });
+
+  // Register HostFS: intercepts OS_File/OS_Find/OS_GBPB/OS_Args for "HostFS::"
+  // paths, passes everything else through to the real ROM FileSwitch.
+  const hostfs = new HostFsHandler(fsRoot);
+  hostfs.register(machine);
 
   machine.loadROM(romData);
   machine.bootROM();

--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -217,13 +217,16 @@ function startMachine(romData: Uint8Array, appHostPath?: string): void {
 
   machine    = new ArchimedesMachine(config, logger);
   wimpHost   = new NativeWimpHost();
-  // In ROM boot mode the real OS handles all non-HostFS file SWIs; we skip
-  // the HLE `fs` option so the dispatcher does not register competing handlers.
+  // fs is passed so ObeyInterpreter can read !Run / !Boot scripts from disk.
+  // The HLE file SWIs it registers are immediately overwritten by HostFsHandler
+  // below, so only HostFS:: paths are served from Node; everything else
+  // passes through to the real ROM FileSwitch.
   dispatcher = new SwiDispatcher(machine, wimpHost, {
     onOutput: (text) => {
       logger.debug(`[RISC OS] ${text}`);
       launcherWindow?.webContents.send("console-output", text);
     },
+    fs: nodeFs,
     onRunBinary: (riscosPath) => {
       logger.debug(`[onRunBinary] loading: ${riscosPath}`);
       try {

--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -241,7 +241,7 @@ function startMachine(romData: Uint8Array, appHostPath?: string): void {
   });
 
   machine.loadROM(romData);
-  machine.start();
+  machine.bootROM();
 
   bootAllApps();
 

--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -151,7 +151,7 @@ function createProgramsBrowserWindow(): BrowserWindow {
 
   if (isDev) {
     win.loadURL("http://localhost:5173/programs-browser.html");
-    win.webContents.openDevTools({ mode: "detach" });
+    win.webContents.once("did-finish-load", () => win.webContents.openDevTools({ mode: "detach" }));
   } else {
     win.loadFile(path.join(__dirname, "../../renderer/programs-browser.html"));
   }

--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -217,16 +217,16 @@ function startMachine(romData: Uint8Array, appHostPath?: string): void {
 
   machine    = new ArchimedesMachine(config, logger);
   wimpHost   = new NativeWimpHost();
-  // fs is passed so ObeyInterpreter can read !Run / !Boot scripts from disk.
-  // The HLE file SWIs it registers are immediately overwritten by HostFsHandler
-  // below, so only HostFS:: paths are served from Node; everything else
-  // passes through to the real ROM FileSwitch.
+  // obeyFs gives the ObeyInterpreter access to !Run / !Boot scripts on disk.
+  // fs is intentionally omitted: in ROM boot mode the real ROM FileSwitch
+  // handles OS_File / OS_Find / etc.; HostFsHandler (registered below)
+  // intercepts only HostFS:: paths and passes everything else through to ROM.
   dispatcher = new SwiDispatcher(machine, wimpHost, {
     onOutput: (text) => {
       logger.debug(`[RISC OS] ${text}`);
       launcherWindow?.webContents.send("console-output", text);
     },
-    fs: nodeFs,
+    obeyFs: nodeFs,
     onRunBinary: (riscosPath) => {
       logger.debug(`[onRunBinary] loading: ${riscosPath}`);
       try {

--- a/packages/electron-shell/src/main/index.ts
+++ b/packages/electron-shell/src/main/index.ts
@@ -151,6 +151,7 @@ function createProgramsBrowserWindow(): BrowserWindow {
 
   if (isDev) {
     win.loadURL("http://localhost:5173/programs-browser.html");
+    win.webContents.openDevTools({ mode: "detach" });
   } else {
     win.loadFile(path.join(__dirname, "../../renderer/programs-browser.html"));
   }

--- a/packages/electron-shell/src/main/menu.ts
+++ b/packages/electron-shell/src/main/menu.ts
@@ -1,7 +1,7 @@
 /**
  * Application menu for the Acorn Desktop launcher window
  */
-import { Menu, app, shell } from "electron";
+import { Menu, app, shell, BrowserWindow as BW } from "electron";
 import type { BrowserWindow } from "electron";
 
 interface MenuCallbacks {
@@ -53,7 +53,11 @@ export function buildAppMenu(win: BrowserWindow | null, cb: MenuCallbacks): Menu
     {
       label: "&View",
       submenu: [
-        { role: "toggleDevTools" },
+        {
+          label: "Toggle Developer Tools",
+          accelerator: process.platform === "darwin" ? "Alt+Command+I" : "Ctrl+Shift+I",
+          click: () => BW.getFocusedWindow()?.webContents.toggleDevTools(),
+        },
         { type: "separator" },
         {
           label: "Full Screen",

--- a/packages/electron-shell/src/preload/programs-browser-preload.ts
+++ b/packages/electron-shell/src/preload/programs-browser-preload.ts
@@ -1,20 +1,26 @@
 import { contextBridge, ipcRenderer } from "electron";
-import { IPC } from "@theprogramminggiantpanda/shared";
+
+// IPC channel names inlined to avoid a workspace-package require() in the
+// sandboxed preload context (shared package is not resolvable at runtime).
+const CH_LIST    = "browser:list-apps";
+const CH_LAUNCH  = "browser:launch-app";
+const CH_INSTALL = "browser:install-app";
+const CH_REFRESH = "browser:refresh";
 
 const browserAPI = {
   listApps: (): Promise<unknown[]> =>
-    ipcRenderer.invoke(IPC.BROWSER_LIST_APPS),
+    ipcRenderer.invoke(CH_LIST),
 
   launchApp: (name: string): Promise<void> =>
-    ipcRenderer.invoke(IPC.BROWSER_LAUNCH_APP, name),
+    ipcRenderer.invoke(CH_LAUNCH, name),
 
   installApp: (hostPath: string): Promise<{ ok: boolean; error?: string }> =>
-    ipcRenderer.invoke(IPC.BROWSER_INSTALL_APP, hostPath),
+    ipcRenderer.invoke(CH_INSTALL, hostPath),
 
   onRefresh: (cb: () => void) => {
     const handler = () => cb();
-    ipcRenderer.on(IPC.BROWSER_REFRESH, handler);
-    return () => ipcRenderer.off(IPC.BROWSER_REFRESH, handler);
+    ipcRenderer.on(CH_REFRESH, handler);
+    return () => ipcRenderer.off(CH_REFRESH, handler);
   },
 };
 

--- a/packages/risc-os/src/swi/dispatcher.ts
+++ b/packages/risc-os/src/swi/dispatcher.ts
@@ -21,7 +21,16 @@ import * as SWI from "../swi-numbers.js";
 export interface DispatcherOptions {
   /** Called when the emulated program writes text output */
   onOutput?: OutputCallback;
-  /** If provided, OS file-system SWIs (OS_File, OS_Find, etc.) are active */
+  /**
+   * Filesystem for the ObeyInterpreter to read !Run / !Boot scripts.
+   * When omitted, Obey cannot execute script files (inline commands still work).
+   */
+  obeyFs?: FileSystemHost;
+  /**
+   * If provided, HLE OS file-system SWIs (OS_File, OS_Find, OS_Args,
+   * OS_BGet, OS_BPut, OS_GBPB, OS_FSControl) are registered on the CPU.
+   * Omit in ROM boot mode — the real ROM FileSwitch handles those SWIs.
+   */
   fs?: FileSystemHost;
   /** Called when an Obey Run command targets an ARM binary */
   onRunBinary?: (riscosPath: string) => void;
@@ -44,7 +53,7 @@ export class SwiDispatcher {
     this.sysvar      = new SystemVariables();
     this.spriteAreas = new SpriteAreaRegistry();
     this.modules     = new ModuleRegistry();
-    this.obey        = new ObeyInterpreter(options.fs, this.sysvar, {
+    this.obey        = new ObeyInterpreter(options.obeyFs ?? options.fs, this.sysvar, {
       onOutput:    options.onOutput,
       onRunBinary: options.onRunBinary,
       spritePool:  this.spriteAreas.system,


### PR DESCRIPTION
Closes #25

## Summary

Shifts the emulator from pure HLE (SWI interception before ROM runs) to a hybrid where the real RISC OS ROM boots and executes, but Wimp rendering is still intercepted natively via BrowserWindows.

### Emulator foundation (`arm-emulator`)
- **IOC**: `IRQA_POWER_ON` asserted on cold reset so the ROM recognises a power-on start; control register read/write at offset 0x00 now handled
- **MEMC**: `onRomAliasRelease` callback fires on any write to the MEMC control register — matches real hardware behaviour where the ROM alias is removed by the first MEMC control write
- **Bus**: wires the MEMC callback so the ROM itself releases the alias during boot (no manual `releaseROMAlias()` needed)
- **Machine**: new `bootROM()` entry point; 50 Hz VBL IRQ unconditionally fired so the ROM task switcher wakes; `startApp()` skips exception-vector overwrite when ROM has already set them up

### SWI passthrough mechanism (`arm-emulator`)
- `SwiHandler` can now return `'passthrough'` to fall through to the ROM's own SWI vector, enabling partial interception (handle only matching paths/reason codes, delegate the rest to ROM)

### HostFS (`electron-shell`)
- New `HostFsHandler` intercepts `OS_File`, `OS_Find`, `OS_Args`, `OS_GBPB`, `OS_FSControl` for paths prefixed with `"HostFS::"`
- Translates `HostFS::$.dir.file` → `{rootDir}/dir/file` and serves via Node.js `fs`
- Implements GBPB 9/10/11 directory enumeration (names + full catalogue info) so the RISC OS Filer can browse HostFS directories natively
- File handles 200–254 reserved for HostFS to avoid colliding with ROM handle allocation
- All non-HostFS paths return `'passthrough'` → ROM FileSwitch handles ADFS/RAM/etc. as normal
- HLE `fs` option dropped from `SwiDispatcher` in ROM boot mode; HostFsHandler registered over the top instead

## Test plan
- [ ] Launch with a RISC OS 3.x ROM in `assets/roms/` — ROM should boot without hang
- [ ] Confirm IOC Timer 0 fires at ~100 Hz and the ROM task switcher runs
- [ ] Use `*HostFS` in the task window to select HostFS as current FS
- [ ] Use `*Dir HostFS::$` and `*Cat` to list the host root directory
- [ ] Open a Filer window on `HostFS::$` — directory entries should appear
- [ ] Double-click a `!App` directory on HostFS — Filer runs `!Run`
- [ ] Verify ADFS/RAM filing system still works (non-HostFS:: paths passthrough)
- [ ] Confirm existing native Wimp BrowserWindow rendering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)